### PR TITLE
LC-2810: Fix for Unsupported Web Server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:10.1.19-jdk21-temurin-jammy
+FROM tomcat:9.0.86-jdk21-corretto-al2
 
 WORKDIR /rustici
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:9.0.86-jdk21-corretto-al2
+FROM tomcat:10.1.19-jdk21-temurin-jammy
 
 WORKDIR /rustici
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:8.0-jre8
+FROM tomcat:9.0.86-jdk21-corretto-al2
 
 WORKDIR /rustici
 


### PR DESCRIPTION
This change upgrades the Tomcat version of Rustici to Tomcat 9.0.86 using the `tomcat:9.0.86-jdk21-corretto-al2` [Docker image](https://hub.docker.com/layers/library/tomcat/9.0.86-jdk21-corretto-al2/images/sha256-4997238b77aa7537b6c51e66b08b708c729047b6d3d230eebac85953054533f3?context=explore)