### PR TITLE
LC-2923 xAPI bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:9.0.86-jdk21-corretto-al2
+FROM tomcat:9.0.86-jdk8-corretto-al2
 
 WORKDIR /rustici
 


### PR DESCRIPTION
- Change tomcat base from `tomcat:9.0.86-jdk21-corretto-al2` to `tomcat:9.0.86-jdk8-corretto-al2`. JDK21 was causing compatibility issues with xAPI packages